### PR TITLE
add python3 shebang line

### DIFF
--- a/bin/akamai-cps
+++ b/bin/akamai-cps
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Copyright 2017 Akamai Technologies, Inc. All Rights Reserved.
 


### PR DESCRIPTION
to comply with https://www.python.org/dev/peps/pep-0394/ and to support systems with both python2 and python3.

fixes #1.