### PR TITLE
Adding flag to ignore duplicate CN.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ The flags of interest are:
 ```
 --file <value>                Input file in yaml or json format with the enrollment details.
 --force                       If specified, will not prompt for confirmation (optional)
+--allow-duplicate-cn          If specified, will allow a certificate to be created with the same CN as an existing certificate
 ```
 
 ### update

--- a/bin/cps.py
+++ b/bin/cps.py
@@ -168,7 +168,8 @@ def cli():
         "Create a new enrollment from a yaml or json input file "
         "(Use --file to specify the filename)",
         [{"name": "force","help": "No value"},
-         {"name": "contract-id", "help": "Contract ID under which Enrollment/Certificate has to be created"}],
+         {"name": "contract-id", "help": "Contract ID under which Enrollment/Certificate has to be created"},
+         {"name": "allow-duplicate-cn", "help": "Allows a new certificate to be created with the same CN as an existing certificate"}],
         [{"name": "file", "help": "Input filename from templates folder to read enrollment details"}])
 
     actions["update"] = create_sub_command(
@@ -261,7 +262,7 @@ def create_sub_command(
             del arg["name"]
             if name == 'force' or name == 'show-expiration' or name == 'json' \
             or name == 'yaml' or name == 'yml' or name == 'leaf' or name == 'csv' or name == 'xlsx' \
-            or name == 'chain' or name == 'info':
+            or name == 'chain' or name == 'info' or name == 'allow-duplicate-cn':
                 optional.add_argument(
                     "--" + name,
                     required=False,
@@ -1304,6 +1305,7 @@ def create(args):
     """
     force = args.force
     fileName = args.file
+    allowDuplicateCn = args.allow_duplicate_cn
     filePath = os.path.join(fileName)
 
     try:
@@ -1402,7 +1404,7 @@ def create(args):
             cps_object = cps(base_url,args.account_key)
             # Send a request to create enrollment using wrapper function
             create_enrollmentResponse = cps_object.create_enrollment(
-                session, contractId, data=updateJsonContent)
+                session, contractId, data=updateJsonContent, allowDuplicateCn=allowDuplicateCn)
             if create_enrollmentResponse.status_code != 200 and create_enrollmentResponse.status_code != 202:
                 print('')
                 root_logger.info('FAILED to create certificate: ')

--- a/bin/cpsApiWrapper.py
+++ b/bin/cpsApiWrapper.py
@@ -48,7 +48,7 @@ class cps(object):
         contracts_response = session.get(contracts_url)
         return contracts_response
 
-    def create_enrollment(self, session, contractId, data):
+    def create_enrollment(self, session, contractId, data, allowDuplicateCn=False):
         """
         Function to Create an Enrollment
 
@@ -68,6 +68,8 @@ class cps(object):
         }
         create_enrollment_url = 'https://' + self.access_hostname + \
             '/cps/v2/enrollments?contractId=' + contractId
+        if allowDuplicateCn:
+            create_enrollment_url = create_enrollment_url + '&allow-duplicate-cn=true'
         if '?' in create_enrollment_url:
             create_enrollment_url = create_enrollment_url + self.account_switch_key
         else:


### PR DESCRIPTION
This addresses Issue #22 

This change adds a new flag, "--allow-duplicate-cn".  If the flag is not added, the behavior will remain as it currently is.

If the flag is added, the allow-duplicate-cn=true parameter is passed to the API, allowing a new certificate to be created with the same CN as an existing certificate.