### PR TITLE
Add arm64 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 edgegrid-python==1.2.1
 requests==2.27.1
 prettytable==0.7.2
-cryptography==3.3.2
+cryptography==38.0.0
 pyyaml==5.4
 xlsxwriter==1.2.8
 urllib3==1.26.5


### PR DESCRIPTION
Hi,

We have been testing cli-cps with an Apple M1 machine, and the cryptography package installation fails. Hovering over their changelog, apparently they have not added arm64 wheels until a recent version. This PR will allow M1 users to install cli-cps without problems.

If you need any extra verification, please do not hesitate to contact us.

Regards,

Roberto